### PR TITLE
Add memory/CPU limit, and parameters to docker run

### DIFF
--- a/run_docker.cwl
+++ b/run_docker.cwl
@@ -19,8 +19,6 @@ inputs:
     type: string
   - id: parentid
     type: string
-  - id: status
-    type: string
   - id: synapse_config
     type: File
   - id: input_dir
@@ -40,8 +38,6 @@ arguments:
     prefix: -d
   - valueFrom: $(inputs.store)
     prefix: --store
-  - valueFrom: $(inputs.status)
-    prefix: --status
   - valueFrom: $(inputs.parentid)
     prefix: --parentid
   - valueFrom: $(inputs.synapse_config.path)

--- a/run_docker.cwl
+++ b/run_docker.cwl
@@ -27,6 +27,10 @@ inputs:
     type: File
   - id: store
     type: boolean?
+  - id: memory
+    type: int
+  - id: cpus
+    type: int
 
 arguments: 
   - valueFrom: $(inputs.docker_script.path)
@@ -44,6 +48,10 @@ arguments:
     prefix: -c
   - valueFrom: $(inputs.input_dir)
     prefix: -i
+  - valueFrom: $(inputs.memory)
+    prefix: --memory
+  - valueFrom: $(inputs.cpus)
+    prefix: --cpus
 
 requirements:
   - class: InitialWorkDirRequirement

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -161,8 +161,6 @@ steps:
         source: "#get_docker_config/docker_registry"
       - id: docker_authentication
         source: "#get_docker_config/docker_authentication"
-      - id: status
-        source: "#validate_docker/status"
       - id: parentid
         source: "#submitterUploadSynId"
       - id: synapse_config


### PR DESCRIPTION
* Add in memory + CPU parameters (implement CPU limitation)
* Don't rely on hardcoded paths in the model, require the model to take `--input` and `--output` parameters.
* Remove status check in run docker step