### PR TITLE
add function to only capture last lines of large log file

### DIFF
--- a/run_docker.py
+++ b/run_docker.py
@@ -50,7 +50,6 @@ def store_log_file(syn, log_filename, parentid, store=True):
             log_tail = get_last_lines(log_filename)
             create_log_file(log_filename, log_tail)
         ent = synapseclient.File(log_filename, parent=parentid)
-
         if store:
             try:
                 syn.store(ent)
@@ -117,7 +116,7 @@ def main(syn, args):
     client.login(username=authen['username'],
                  password=authen['password'],
                  registry="https://docker.synapse.org")
-    # dockercfg_path=".docker/config.json")
+                 # dockercfg_path=".docker/config.json")
 
     print(getpass.getuser())
 

--- a/run_docker.py
+++ b/run_docker.py
@@ -27,11 +27,15 @@ def get_last_lines(log_filename, n=5):
     with open(log_filename, "rb") as f:
         try:
             f.seek(-2, os.SEEK_END)
+            # Keep reading, starting at the end, until n lines is read.
             while lines < n:
                 f.seek(-2, os.SEEK_CUR)
                 if f.read(1) == b"\n":
                     lines += 1
         except OSError:
+            # If file only contains one line, then only read that one
+            # line.  This exception will probably never occur, but
+            # adding it in, just in case.
             f.seek(0)
         last_lines = f.read().decode()
     return last_lines
@@ -113,7 +117,7 @@ def main(syn, args):
     client.login(username=authen['username'],
                  password=authen['password'],
                  registry="https://docker.synapse.org")
-                 # dockercfg_path=".docker/config.json")
+    # dockercfg_path=".docker/config.json")
 
     print(getpass.getuser())
 


### PR DESCRIPTION
### Current Issue
When Docker logs are larger than 50Kb, nothing gets loaded to Synapse.  This makes it so participants are unable to debug their models.

### Suggested fix
Re-write the log file so that it only contains the last 5 lines of any log file that is >50Kb.  I have tested this for the PTB challenge and it works great, e.g. this log was originally 500+ Kb but now only contains the last 5 lines:

<img width="565" alt="Screen Shot 2022-08-23 at 10 50 16 PM" src="https://user-images.githubusercontent.com/9377970/186341057-37102c9f-41cf-465f-9b83-d65db87019b4.png">

The one caveat with this approach is that it assumes the error message can be found within the last 5 lines of the log, which is true for Python and R, but maybe not other languages.